### PR TITLE
Impl core::default::Default for UserAgentParser

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,11 @@ readme        = "README.md"
 
 keywords      = ["user", "agent", "parser", "uap", "uaparser"]
 
+[features]
+default = ["default-impl"]
+
+default-impl = []
+
 [dependencies]
 serde = "1.0.88"
 serde_yaml = "0.8.8"

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -139,6 +139,13 @@ impl UserAgentParser {
     }
 }
 
+#[cfg(feature = "default-impl")]
+impl Default for UserAgentParser {
+    fn default() -> UserAgentParser {
+        UserAgentParser::from_bytes(include_bytes!("../../src/core/regexes.yaml")).expect("Failed to create UserAgentParser from UA standard YAML file.")
+    }
+}
+
 pub(self) fn none_if_str_is_empty(s: &str) -> Option<&str> {
     if !s.is_empty() {
         Some(s)


### PR DESCRIPTION
This creates a builtin UserAgentParser using the standard regex specification.
This does increase binary size by storing the yaml file in `.rodata`, but can be removed by disabling the feature.

Requires the `core` git module to be initialized.