### PR TITLE
Derive common traits as specified in the Rust API guidelines

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -2,7 +2,7 @@ use super::{Deserialize, Device, UserAgent, OS};
 
 /// Houses the `Device`, `OS`, and `UserAgent` structs, which each get parsed
 /// out from a user agent string by a `UserAgentParser`.
-#[derive(Debug, Deserialize, PartialEq)]
+#[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq)]
 pub struct Client {
     pub device: Device,
     pub os: OS,

--- a/src/device.rs
+++ b/src/device.rs
@@ -5,7 +5,7 @@ pub type Brand = String;
 pub type Model = String;
 
 /// Describes the `Family`, `Brand` and `Model` of a `Device`
-#[derive(Clone, Debug, Deserialize, PartialEq)]
+#[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq)]
 pub struct Device {
     pub family: Family,
     pub brand: Option<Brand>,

--- a/src/os.rs
+++ b/src/os.rs
@@ -8,7 +8,7 @@ pub type PatchMinor = String;
 
 /// Describes the `Family` as well as the `Major`, `Minor`, `Patch`, and
 /// `PatchMinor` versions of an `OS`
-#[derive(Clone, Debug, Deserialize, PartialEq)]
+#[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq)]
 pub struct OS {
     pub family: Family,
     pub major: Option<Major>,

--- a/src/user_agent.rs
+++ b/src/user_agent.rs
@@ -7,7 +7,7 @@ pub type Patch = String;
 
 /// Describes the `Family` as well as the `Major`, `Minor`, and `Patch` versions
 /// of a `UserAgent` client
-#[derive(Clone, Debug, Deserialize, PartialEq)]
+#[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq)]
 pub struct UserAgent {
     pub family: Family,
     pub major: Option<Major>,


### PR DESCRIPTION
Derive a number of common traits recommended by the [Rust API guidelines](https://rust-lang.github.io/api-guidelines/interoperability.html#types-eagerly-implement-common-traits-c-common-traits). This enables interoperability with data structures in the standard library.