### PR TITLE
Derive Serialize

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -1,8 +1,8 @@
-use super::{Deserialize, Device, UserAgent, OS};
+use super::{Serialize, Deserialize, Device, UserAgent, OS};
 
 /// Houses the `Device`, `OS`, and `UserAgent` structs, which each get parsed
 /// out from a user agent string by a `UserAgentParser`.
-#[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq)]
+#[derive(Clone, Debug, Serialize, Deserialize, Eq, Hash, PartialEq)]
 pub struct Client {
     pub device: Device,
     pub os: OS,

--- a/src/device.rs
+++ b/src/device.rs
@@ -1,11 +1,11 @@
-use super::Deserialize;
+use super::{Deserialize, Serialize};
 
 pub type Family = String;
 pub type Brand = String;
 pub type Model = String;
 
 /// Describes the `Family`, `Brand` and `Model` of a `Device`
-#[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq)]
+#[derive(Clone, Debug, Serialize, Deserialize, Eq, Hash, PartialEq)]
 pub struct Device {
     pub family: Family,
     pub brand: Option<Brand>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,7 @@
 //! assert_eq!(client.user_agent, user_agent);
 //! ```
 
-use serde_derive::Deserialize;
+use serde_derive::{Serialize, Deserialize};
 
 mod client;
 mod device;

--- a/src/os.rs
+++ b/src/os.rs
@@ -1,4 +1,4 @@
-use super::Deserialize;
+use super::{Deserialize, Serialize};
 
 pub type Family = String;
 pub type Major = String;
@@ -8,7 +8,7 @@ pub type PatchMinor = String;
 
 /// Describes the `Family` as well as the `Major`, `Minor`, `Patch`, and
 /// `PatchMinor` versions of an `OS`
-#[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq)]
+#[derive(Clone, Debug, Serialize, Deserialize, Eq, Hash, PartialEq)]
 pub struct OS {
     pub family: Family,
     pub major: Option<Major>,

--- a/src/user_agent.rs
+++ b/src/user_agent.rs
@@ -1,4 +1,4 @@
-use super::Deserialize;
+use super::{Deserialize, Serialize};
 
 pub type Family = String;
 pub type Major = String;
@@ -7,7 +7,7 @@ pub type Patch = String;
 
 /// Describes the `Family` as well as the `Major`, `Minor`, and `Patch` versions
 /// of a `UserAgent` client
-#[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq)]
+#[derive(Clone, Debug, Deserialize, Serialize, Eq, Hash, PartialEq)]
 pub struct UserAgent {
     pub family: Family,
     pub major: Option<Major>,


### PR DESCRIPTION
I need to store a pre-compute result for a bunch of `Client`s, so I thought why not add `Serialize` upstream.