### PR TITLE
Replace fancyregex with regex

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,9 @@ readme        = "README.md"
 keywords      = ["user", "agent", "parser", "uap", "uaparser"]
 
 [dependencies]
+lazy_static = "1.4.0"
+regex = "1.5.4"
 serde = "1.0.110"
 serde_yaml = "0.8.12"
 serde_derive = "1.0.110"
 derive_more = "0.99.7"
-fancy-regex = "0.3.5"

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1,5 +1,7 @@
+use std::borrow::Cow;
+
 use derive_more::{Display, From};
-use serde_yaml;
+use regex::Regex;
 
 use super::{
     client::Client,
@@ -39,9 +41,9 @@ pub struct UserAgentParser {
 impl Parser for UserAgentParser {
     /// Returns the full `Client` info when given a user agent string
     fn parse(&self, user_agent: &str) -> Client {
-        let device = self.parse_device(&user_agent);
-        let os = self.parse_os(&user_agent);
-        let user_agent = self.parse_user_agent(&user_agent);
+        let device = self.parse_device(user_agent);
+        let os = self.parse_os(user_agent);
+        let user_agent = self.parse_user_agent(user_agent);
 
         Client {
             device,
@@ -54,7 +56,7 @@ impl Parser for UserAgentParser {
     fn parse_device(&self, user_agent: &str) -> Device {
         self.device_matchers
             .iter()
-            .filter_map(|matcher| matcher.try_parse(&user_agent))
+            .filter_map(|matcher| matcher.try_parse(user_agent))
             .take(1)
             .next()
             .unwrap_or_default()
@@ -64,7 +66,7 @@ impl Parser for UserAgentParser {
     fn parse_os(&self, user_agent: &str) -> OS {
         self.os_matchers
             .iter()
-            .filter_map(|matcher| matcher.try_parse(&user_agent))
+            .filter_map(|matcher| matcher.try_parse(user_agent))
             .take(1)
             .next()
             .unwrap_or_default()
@@ -74,7 +76,7 @@ impl Parser for UserAgentParser {
     fn parse_user_agent(&self, user_agent: &str) -> UserAgent {
         self.user_agent_matchers
             .iter()
-            .filter_map(|matcher| matcher.try_parse(&user_agent))
+            .filter_map(|matcher| matcher.try_parse(user_agent))
             .take(1)
             .next()
             .unwrap_or_default()
@@ -85,7 +87,7 @@ impl UserAgentParser {
     /// Attempts to construct a `UserAgentParser` from the path to a file
     pub fn from_yaml(path: &str) -> Result<UserAgentParser, Error> {
         let file = std::fs::File::open(path)?;
-        Ok(UserAgentParser::from_file(file)?)
+        UserAgentParser::from_file(file)
     }
 
     /// Attempts to construct a `UserAgentParser` from a slice of raw bytes. The
@@ -100,7 +102,7 @@ impl UserAgentParser {
     /// ```
     pub fn from_bytes(bytes: &[u8]) -> Result<UserAgentParser, Error> {
         let regex_file: RegexFile = serde_yaml::from_slice(bytes)?;
-        Ok(UserAgentParser::try_from(regex_file)?)
+        UserAgentParser::try_from(regex_file)
     }
 
     /// Attempts to construct a `UserAgentParser` from a reference to an open
@@ -108,7 +110,7 @@ impl UserAgentParser {
     /// all the various implementations of the UA Parser library.
     pub fn from_file(file: std::fs::File) -> Result<UserAgentParser, Error> {
         let regex_file: RegexFile = serde_yaml::from_reader(file)?;
-        Ok(UserAgentParser::try_from(regex_file)?)
+        UserAgentParser::try_from(regex_file)
     }
 
     pub fn try_from(regex_file: RegexFile) -> Result<UserAgentParser, Error> {
@@ -144,16 +146,24 @@ pub(self) fn none_if_empty<T: AsRef<str>>(s: T) -> Option<T> {
     }
 }
 
-pub(self) fn replace(replacement: &str, captures: &fancy_regex::Captures) -> String {
+pub(self) fn replace(replacement: &str, captures: &regex::Captures) -> String {
     if replacement.contains('$') && captures.len() > 0 {
         (1..=captures.len())
             .fold(replacement.to_owned(), |state: String, i: usize| {
                 let group = captures.get(i).map(|x| x.as_str()).unwrap_or("");
-                state.replace(&format!("${}", i), &group)
+                state.replace(&format!("${}", i), group)
             })
             .trim()
             .to_owned()
     } else {
         replacement.to_owned()
     }
+}
+
+lazy_static::lazy_static! {
+    static ref INVALID_ESCAPES: Regex = Regex::new("\\\\([! /])").unwrap();
+}
+
+fn clean_escapes(pattern: &str) -> Cow<'_, str> {
+    INVALID_ESCAPES.replace_all(pattern, "$1")
 }

--- a/src/parser/os.rs
+++ b/src/parser/os.rs
@@ -2,12 +2,12 @@ use super::*;
 
 #[derive(Debug, Display, From)]
 pub enum Error {
-    Regex(fancy_regex::Error),
+    Regex(regex::Error),
 }
 
 #[derive(Debug)]
 pub struct Matcher {
-    regex: fancy_regex::Regex,
+    regex: regex::Regex,
     os_replacement: Option<String>,
     os_v1_replacement: Option<String>,
     os_v2_replacement: Option<String>,
@@ -18,9 +18,9 @@ impl SubParser for Matcher {
     type Item = OS;
 
     fn try_parse(&self, text: &str) -> Option<Self::Item> {
-        if let Ok(Some(captures)) = self.regex.captures(text) {
+        if let Some(captures) = self.regex.captures(text) {
             let family: String = if let Some(os_replacement) = &self.os_replacement {
-                replace(&os_replacement, &captures)
+                replace(os_replacement, &captures)
             } else {
                 captures
                     .get(1)
@@ -31,7 +31,7 @@ impl SubParser for Matcher {
 
             let major: Option<String> =
                 if let Some(os_v1_replacement) = &self.os_v1_replacement {
-                    none_if_empty(replace(&os_v1_replacement, &captures))
+                    none_if_empty(replace(os_v1_replacement, &captures))
                 } else {
                     captures
                         .get(2)
@@ -42,7 +42,7 @@ impl SubParser for Matcher {
 
             let minor: Option<String> =
                 if let Some(os_v2_replacement) = &self.os_v2_replacement {
-                    none_if_empty(replace(&os_v2_replacement, &captures))
+                    none_if_empty(replace(os_v2_replacement, &captures))
                 } else {
                     captures
                         .get(3)
@@ -53,7 +53,7 @@ impl SubParser for Matcher {
 
             let patch: Option<String> =
                 if let Some(os_v3_replacement) = &self.os_v3_replacement {
-                    none_if_empty(replace(&os_v3_replacement, &captures))
+                    none_if_empty(replace(os_v3_replacement, &captures))
                 } else {
                     captures
                         .get(4)
@@ -83,7 +83,7 @@ impl SubParser for Matcher {
 
 impl Matcher {
     pub fn try_from(entry: OSParserEntry) -> Result<Matcher, Error> {
-        let regex = fancy_regex::Regex::new(&entry.regex);
+        let regex = regex::Regex::new(&clean_escapes(&entry.regex));
 
         Ok(Matcher {
             regex: regex?,


### PR DESCRIPTION
Turns out that the plain regex crate can handle all regexes of uap-core. From what I could see, fancyregex tries to forward as much as possible to a plain `regex::Regex` in such cases, it's possible to get rid of the dependency. As part of the refactor, I was able to simplify a few double-references.

There is one difference: The `regex` crate rejects meaningless escape sequences. There are some instances in `uap-core` both in the referenced version 0.10 as well as in the latest 0.15. I've added a `clean_escapes` method that removes such escapes if they occur. 

To clean invalid escapes I chose a regex, since we already have the dependency in. There are more elaborate manual ways to write this with little performance gains, but I opted for less code.