### PR TITLE
Add benchmark tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,3 +19,10 @@ serde_yaml = "0.8.12"
 serde_derive = "1.0.110"
 derive_more = "0.99.7"
 fancy-regex = "0.3.5"
+
+[dev-dependencies]
+criterion = "0.3.5"
+
+[[bench]]
+name = "benchmark"
+harness = false

--- a/benches/benchmark.rs
+++ b/benches/benchmark.rs
@@ -1,0 +1,66 @@
+use std::fs::File;
+
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use serde_derive::Deserialize;
+use uaparser::{Parser, UserAgentParser};
+
+#[derive(Deserialize, Debug)]
+struct TestCase {
+    user_agent_string: String,
+}
+
+#[derive(Deserialize, Debug)]
+struct TestCases {
+    test_cases: Vec<TestCase>,
+}
+
+fn bench_os(c: &mut Criterion) {
+    let parser = UserAgentParser::from_yaml("./src/core/regexes.yaml")
+        .expect("Parser creation failed");
+
+    let file = File::open("./src/core/tests/test_os.yaml").unwrap();
+    let test_cases: TestCases = serde_yaml::from_reader(file).unwrap();
+
+    c.bench_function("parse_os", |b| {
+        b.iter(|| {
+            for case in &test_cases.test_cases {
+                black_box(parser.parse_os(&case.user_agent_string));
+            }
+        })
+    });
+}
+
+fn bench_device(c: &mut Criterion) {
+    let parser = UserAgentParser::from_yaml("./src/core/regexes.yaml")
+        .expect("Parser creation failed");
+
+    let file = File::open("./src/core/tests/test_device.yaml").unwrap();
+    let test_cases: TestCases = serde_yaml::from_reader(file).unwrap();
+
+    c.bench_function("parse_device", |b| {
+        b.iter(|| {
+            for case in &test_cases.test_cases {
+                black_box(parser.parse_device(&case.user_agent_string));
+            }
+        })
+    });
+}
+
+fn bench_ua(c: &mut Criterion) {
+    let parser = UserAgentParser::from_yaml("./src/core/regexes.yaml")
+        .expect("Parser creation failed");
+
+    let file = std::fs::File::open("./src/core/tests/test_ua.yaml").unwrap();
+    let test_cases: TestCases = serde_yaml::from_reader(file).unwrap();
+
+    c.bench_function("parse_user_agent", |b| {
+        b.iter(|| {
+            for case in &test_cases.test_cases {
+                black_box(parser.parse_user_agent(&case.user_agent_string));
+            }
+        })
+    });
+}
+
+criterion_group!(benches, bench_device, bench_os, bench_ua);
+criterion_main!(benches);


### PR DESCRIPTION
This adds a very simple set of benchmark tests for the three parse methods based
on the existing unit tests. Due to the large number of regexes in the test
input, I've opted to loop through all of them per bench iteration. This creates
a rather quick and stable benchmark test. However, it weighs every test input
the same, which doesn't properly represent real world distributions.

I'm happy to contribute CI and a small optimization once this is merged.

