### PR TITLE
Exit early in device and OS matchers

### DIFF
--- a/src/parser/device.rs
+++ b/src/parser/device.rs
@@ -17,6 +17,10 @@ impl SubParser for Matcher {
     type Item = Device;
 
     fn try_parse(&self, text: &str) -> Option<Self::Item> {
+        if !self.regex.is_match(text) {
+            return None;
+        }
+
         if let Some(captures) = self.regex.captures(text) {
             let family: String =
                 if let Some(device_replacement) = &self.device_replacement {

--- a/src/parser/os.rs
+++ b/src/parser/os.rs
@@ -18,6 +18,10 @@ impl SubParser for Matcher {
     type Item = OS;
 
     fn try_parse(&self, text: &str) -> Option<Self::Item> {
+        if !self.regex.is_match(text) {
+            return None;
+        }
+
         if let Some(captures) = self.regex.captures(text) {
             let family: String = if let Some(os_replacement) = &self.os_replacement {
                 replace(os_replacement, &captures)


### PR DESCRIPTION
It's possible to improve the performance of `parse_device` and `parse_os` on average based on the samples contained in the benchmark test suite. Given that this crate tries a large number of regexes only so it can match a single one, `Regex::is_match` avoids the overhead of creating captures in the majority of cases. Only the single matching Regex gets called a second time, which is a small price to pay.

Here are the results from the benchmark test suite:

```
parse_device            time:   [1.0200 s 1.0205 s 1.0211 s]
                        change: [-13.326% -12.967% -12.665%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 4 outliers among 100 measurements (4.00%)
  1 (1.00%) low severe
  3 (3.00%) high mild

parse_os                time:   [2.3172 ms 2.3209 ms 2.3239 ms]
                        change: [-55.933% -55.774% -55.624%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 11 outliers among 100 measurements (11.00%)
  2 (2.00%) low severe
  1 (1.00%) low mild
  4 (4.00%) high mild
  4 (4.00%) high severe

parse_user_agent        time:   [177.61 ms 177.86 ms 178.05 ms]
                        change: [-1.2917% -1.0907% -0.8966%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 8 outliers among 100 measurements (8.00%)
  3 (3.00%) low severe
  5 (5.00%) high mild
```