### PR TITLE
Use `Cow<'a, str>` instead of `String` where possible

### DIFF
--- a/benches/benchmark.rs
+++ b/benches/benchmark.rs
@@ -1,4 +1,4 @@
-use std::fs::File;
+use std::{fs::File, time::Duration};
 
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use serde_derive::Deserialize;
@@ -62,5 +62,21 @@ fn bench_ua(c: &mut Criterion) {
     });
 }
 
-criterion_group!(benches, bench_device, bench_os, bench_ua);
+criterion_group!(
+    name = benches;
+    config = Criterion::default()
+        .warm_up_time(Duration::from_secs(25))
+        .measurement_time(Duration::from_secs(180))
+        // degree of noise to ignore in measurements, here 1%
+        .noise_threshold(0.01)
+        // likelihood of noise registering as difference, here 5%
+        .significance_level(0.05)
+        // likelihood of capturing the true runtime, here 95%
+        .confidence_level(0.95)
+        // total number of bootstrap resamples, higher is less noisy but slower
+        .nresamples(10_000)
+        // total samples to collect within the set measurement time
+        .sample_size(100);
+    targets = bench_device, bench_os, bench_ua
+);
 criterion_main!(benches);

--- a/src/client.rs
+++ b/src/client.rs
@@ -3,8 +3,8 @@ use super::{Deserialize, Device, Serialize, UserAgent, OS};
 /// Houses the `Device`, `OS`, and `UserAgent` structs, which each get parsed
 /// out from a user agent string by a `UserAgentParser`.
 #[derive(Clone, Debug, Serialize, Deserialize, Eq, Hash, PartialEq)]
-pub struct Client {
-    pub device: Device,
-    pub os: OS,
-    pub user_agent: UserAgent,
+pub struct Client<'a> {
+    pub device: Device<'a>,
+    pub os: OS<'a>,
+    pub user_agent: UserAgent<'a>,
 }

--- a/src/device.rs
+++ b/src/device.rs
@@ -1,21 +1,18 @@
 use super::{Deserialize, Serialize};
-
-pub type Family = String;
-pub type Brand = String;
-pub type Model = String;
+use std::borrow::Cow;
 
 /// Describes the `Family`, `Brand` and `Model` of a `Device`
 #[derive(Clone, Debug, Serialize, Deserialize, Eq, Hash, PartialEq)]
-pub struct Device {
-    pub family: Family,
-    pub brand: Option<Brand>,
-    pub model: Option<Model>,
+pub struct Device<'a> {
+    pub family: Cow<'a, str>,
+    pub brand: Option<Cow<'a, str>>,
+    pub model: Option<Cow<'a, str>>,
 }
 
-impl Default for Device {
-    fn default() -> Device {
-        Device {
-            family: "Other".to_string(),
+impl<'a> Default for Device<'a> {
+    fn default() -> Self {
+        Self {
+            family: Cow::Borrowed("Other"),
             brand: None,
             model: None,
         }

--- a/src/os.rs
+++ b/src/os.rs
@@ -1,26 +1,22 @@
-use super::{Deserialize, Serialize};
+use std::borrow::Cow;
 
-pub type Family = String;
-pub type Major = String;
-pub type Minor = String;
-pub type Patch = String;
-pub type PatchMinor = String;
+use super::{Deserialize, Serialize};
 
 /// Describes the `Family` as well as the `Major`, `Minor`, `Patch`, and
 /// `PatchMinor` versions of an `OS`
 #[derive(Clone, Debug, Serialize, Deserialize, Eq, Hash, PartialEq)]
-pub struct OS {
-    pub family: Family,
-    pub major: Option<Major>,
-    pub minor: Option<Minor>,
-    pub patch: Option<Patch>,
-    pub patch_minor: Option<PatchMinor>,
+pub struct OS<'a> {
+    pub family: Cow<'a, str>,
+    pub major: Option<Cow<'a, str>>,
+    pub minor: Option<Cow<'a, str>>,
+    pub patch: Option<Cow<'a, str>>,
+    pub patch_minor: Option<Cow<'a, str>>,
 }
 
-impl Default for OS {
-    fn default() -> OS {
-        OS {
-            family: "Other".to_string(),
+impl<'a> Default for OS<'a> {
+    fn default() -> Self {
+        Self {
+            family: Cow::Borrowed("Other"),
             major: None,
             minor: None,
             patch: None,

--- a/src/parser/device.rs
+++ b/src/parser/device.rs
@@ -11,44 +11,54 @@ pub struct Matcher {
     device_replacement: Option<String>,
     brand_replacement: Option<String>,
     model_replacement: Option<String>,
+    device_replacement_has_group: bool,
+    brand_replacement_has_group: bool,
+    model_replacement_has_group: bool,
 }
 
-impl SubParser for Matcher {
-    type Item = Device;
+impl<'a> SubParser<'a> for Matcher {
+    type Item = Device<'a>;
 
-    fn try_parse(&self, text: &str) -> Option<Self::Item> {
+    fn try_parse(&self, text: &'a str) -> Option<Self::Item> {
         if !self.regex.is_match(text) {
             return None;
         }
 
         if let Some(captures) = self.regex.captures(text) {
-            let family: String =
+            let family: Cow<'a, str> =
                 if let Some(device_replacement) = &self.device_replacement {
-                    replace(device_replacement, &captures)
+                    replace_cow(
+                        device_replacement,
+                        self.device_replacement_has_group,
+                        &captures,
+                    )
                 } else {
                     captures
                         .get(1)
                         .map(|x| x.as_str())
                         .and_then(none_if_empty)
-                        .map(ToString::to_string)?
+                        .map(Cow::Borrowed)?
                 };
 
-            let brand: Option<String> =
-                if let Some(brand_replacement) = &self.brand_replacement {
-                    none_if_empty(replace(brand_replacement, &captures))
-                } else {
-                    None
-                };
+            let brand: Option<Cow<'a, str>> = self
+                .brand_replacement
+                .as_ref()
+                .map(|br| replace_cow(br, self.brand_replacement_has_group, &captures))
+                .and_then(none_if_empty);
 
-            let model: Option<String> =
+            let model: Option<Cow<'a, str>> =
                 if let Some(model_replacement) = &self.model_replacement {
-                    none_if_empty(replace(model_replacement, &captures))
+                    none_if_empty(replace_cow(
+                        model_replacement,
+                        self.model_replacement_has_group,
+                        &captures,
+                    ))
                 } else {
                     captures
                         .get(1)
                         .map(|x| x.as_str())
                         .and_then(none_if_empty)
-                        .map(ToString::to_string)
+                        .map(Cow::Borrowed)
                 };
 
             Some(Device {
@@ -64,20 +74,32 @@ impl SubParser for Matcher {
 
 impl Matcher {
     pub fn try_from(entry: DeviceParserEntry) -> Result<Matcher, Error> {
-        let regex_with_flags =
-            if !entry.regex_flag.as_ref().map_or(true, String::is_empty) {
-                format!("(?{}){}", entry.regex_flag.unwrap_or_default(), entry.regex)
-            } else {
-                entry.regex
-            };
+        let regex_with_flags = if entry.regex_flag.as_ref().map_or(true, String::is_empty)
+        {
+            entry.regex
+        } else {
+            format!("(?{}){}", entry.regex_flag.unwrap_or_default(), entry.regex)
+        };
         let regex = regex::RegexBuilder::new(&clean_escapes(&regex_with_flags))
             .size_limit(20 * (1 << 20))
             .build();
 
         Ok(Matcher {
             regex: regex?,
+            device_replacement_has_group: entry
+                .device_replacement
+                .as_ref()
+                .map_or(false, |x| has_group(x.as_str())),
             device_replacement: entry.device_replacement,
+            brand_replacement_has_group: entry
+                .brand_replacement
+                .as_ref()
+                .map_or(false, |x| has_group(x.as_str())),
             brand_replacement: entry.brand_replacement,
+            model_replacement_has_group: entry
+                .model_replacement
+                .as_ref()
+                .map_or(false, |x| has_group(x.as_str())),
             model_replacement: entry.model_replacement,
         })
     }

--- a/src/parser/os.rs
+++ b/src/parser/os.rs
@@ -6,71 +6,89 @@ pub enum Error {
 }
 
 #[derive(Debug)]
+#[allow(clippy::struct_excessive_bools)]
 pub struct Matcher {
     regex: regex::Regex,
     os_replacement: Option<String>,
     os_v1_replacement: Option<String>,
     os_v2_replacement: Option<String>,
     os_v3_replacement: Option<String>,
+    os_replacement_has_group: bool,
+    os_v1_replacement_has_group: bool,
+    os_v2_replacement_has_group: bool,
+    os_v3_replacement_has_group: bool,
 }
 
-impl SubParser for Matcher {
-    type Item = OS;
+impl<'a> SubParser<'a> for Matcher {
+    type Item = OS<'a>;
 
-    fn try_parse(&self, text: &str) -> Option<Self::Item> {
+    fn try_parse(&self, text: &'a str) -> Option<Self::Item> {
         if !self.regex.is_match(text) {
             return None;
         }
 
         if let Some(captures) = self.regex.captures(text) {
-            let family: String = if let Some(os_replacement) = &self.os_replacement {
-                replace(os_replacement, &captures)
+            let family: Cow<'a, str> = if let Some(os_replacement) = &self.os_replacement
+            {
+                replace_cow(os_replacement, self.os_replacement_has_group, &captures)
             } else {
                 captures
                     .get(1)
                     .map(|x| x.as_str())
                     .and_then(none_if_empty)
-                    .map(ToString::to_string)?
+                    .map(Cow::Borrowed)?
             };
 
-            let major: Option<String> =
+            let major: Option<Cow<'a, str>> =
                 if let Some(os_v1_replacement) = &self.os_v1_replacement {
-                    none_if_empty(replace(os_v1_replacement, &captures))
+                    none_if_empty(replace_cow(
+                        os_v1_replacement,
+                        self.os_v1_replacement_has_group,
+                        &captures,
+                    ))
                 } else {
                     captures
                         .get(2)
                         .map(|x| x.as_str())
                         .and_then(none_if_empty)
-                        .map(ToString::to_string)
+                        .map(Cow::Borrowed)
                 };
 
-            let minor: Option<String> =
+            let minor: Option<Cow<'a, str>> =
                 if let Some(os_v2_replacement) = &self.os_v2_replacement {
-                    none_if_empty(replace(os_v2_replacement, &captures))
+                    none_if_empty(replace_cow(
+                        os_v2_replacement,
+                        self.os_v2_replacement_has_group,
+                        &captures,
+                    ))
                 } else {
                     captures
                         .get(3)
                         .map(|x| x.as_str())
                         .and_then(none_if_empty)
-                        .map(ToString::to_string)
+                        .map(Cow::Borrowed)
                 };
 
-            let patch: Option<String> =
+            let patch: Option<Cow<'a, str>> =
                 if let Some(os_v3_replacement) = &self.os_v3_replacement {
-                    none_if_empty(replace(os_v3_replacement, &captures))
+                    none_if_empty(replace_cow(
+                        os_v3_replacement,
+                        self.os_v3_replacement_has_group,
+                        &captures,
+                    ))
                 } else {
                     captures
                         .get(4)
                         .map(|x| x.as_str())
                         .and_then(none_if_empty)
-                        .map(ToString::to_string)
+                        .map(Cow::Borrowed)
                 };
 
-            let patch_minor: Option<String> = captures
+            let patch_minor: Option<Cow<'a, str>> = captures
                 .get(5)
                 .map(|x| x.as_str())
                 .and_then(none_if_empty)
-                .map(ToString::to_string);
+                .map(Cow::Borrowed);
 
             Some(OS {
                 family,
@@ -91,9 +109,25 @@ impl Matcher {
 
         Ok(Matcher {
             regex: regex?,
+            os_replacement_has_group: entry
+                .os_replacement
+                .as_ref()
+                .map_or(false, |x| has_group(x.as_str())),
             os_replacement: entry.os_replacement,
+            os_v1_replacement_has_group: entry
+                .os_v1_replacement
+                .as_ref()
+                .map_or(false, |x| has_group(x.as_str())),
             os_v1_replacement: entry.os_v1_replacement,
+            os_v2_replacement_has_group: entry
+                .os_v2_replacement
+                .as_ref()
+                .map_or(false, |x| has_group(x.as_str())),
             os_v2_replacement: entry.os_v2_replacement,
+            os_v3_replacement_has_group: entry
+                .os_v3_replacement
+                .as_ref()
+                .map_or(false, |x| has_group(x.as_str())),
             os_v3_replacement: entry.os_v3_replacement,
         })
     }

--- a/src/user_agent.rs
+++ b/src/user_agent.rs
@@ -1,24 +1,21 @@
-use super::{Deserialize, Serialize};
+use std::borrow::Cow;
 
-pub type Family = String;
-pub type Major = String;
-pub type Minor = String;
-pub type Patch = String;
+use super::{Deserialize, Serialize};
 
 /// Describes the `Family` as well as the `Major`, `Minor`, and `Patch` versions
 /// of a `UserAgent` client
 #[derive(Clone, Debug, Deserialize, Serialize, Eq, Hash, PartialEq)]
-pub struct UserAgent {
-    pub family: Family,
-    pub major: Option<Major>,
-    pub minor: Option<Minor>,
-    pub patch: Option<Patch>,
+pub struct UserAgent<'a> {
+    pub family: Cow<'a, str>,
+    pub major: Option<Cow<'a, str>>,
+    pub minor: Option<Cow<'a, str>>,
+    pub patch: Option<Cow<'a, str>>,
 }
 
-impl Default for UserAgent {
-    fn default() -> UserAgent {
-        UserAgent {
-            family: "Other".to_string(),
+impl<'a> Default for UserAgent<'a> {
+    fn default() -> Self {
+        Self {
+            family: Cow::Borrowed("Other"),
             major: None,
             minor: None,
             patch: None,


### PR DESCRIPTION
In the [Vector](https://github.com/vectordotdev/vector) project we've noticed that user agent parsing results in a lot of small string allocations. This commit adjusts the API of this crate to avoid allocating small strings where possible, unfortunately breaking the API contract with existing users. Performance as measured by the microbenchmarks does appear to be overall improved. 

Vector macro behavior did not change, per [our throughput monitoring](https://github.com/vectordotdev/vector/pull/12601#issuecomment-1118110736), but we also do not measure memory utilization in the performance rig.

Signed-off-by: Brian L. Troutwine <brian@troutwine.us>