### PR TITLE
adding the clone trait to matcher and UAParser

### DIFF
--- a/src/parser/device.rs
+++ b/src/parser/device.rs
@@ -5,7 +5,7 @@ pub enum Error {
     Regex(regex::Error),
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Matcher {
     regex: regex::bytes::Regex,
     device_replacement: Option<String>,

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -35,7 +35,7 @@ impl std::error::Error for Error {}
 
 /// Handles the actual parsing of a user agent string by delegating to
 /// the respective `SubParser`
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct UserAgentParser {
     device_matchers: Vec<device::Matcher>,
     os_matchers: Vec<os::Matcher>,

--- a/src/parser/os.rs
+++ b/src/parser/os.rs
@@ -5,7 +5,7 @@ pub enum Error {
     Regex(regex::Error),
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 #[allow(clippy::struct_excessive_bools)]
 pub struct Matcher {
     regex: regex::bytes::Regex,

--- a/src/parser/user_agent.rs
+++ b/src/parser/user_agent.rs
@@ -5,7 +5,7 @@ pub enum Error {
     Regex(regex::Error),
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Matcher {
     regex: regex::bytes::Regex,
     family_replacement_has_group: bool,


### PR DESCRIPTION
If the UA Parser is used as an extension in the tokio layer , it requires the object can be cloned for every request.  It is better to allow the clone trait or expose the Matcher object as a public object to allow others to implement the Clone Trait.  